### PR TITLE
Adjoint instead of transpose in tests

### DIFF
--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -30,7 +30,7 @@ end
 @testset "Rounding SVDLikeRepresentation" begin
     Q = qr(randn(100,100)).Q
     D = Diagonal([2.0^(-j) for j in 1:100])
-    A = exp(Matrix(Q))*D*exp(Matrix(transpose(Q)))
+    A = exp(Matrix(Q))*D*exp(Matrix(Q'))
     LRA = truncated_svd(A, tol = 0.01)
 
     # svd based rounding 


### PR DESCRIPTION
This came up in a nanosoldier run related to https://github.com/JuliaLang/julia/pull/46196. While `transpose(Q)` can be constructed, there exist no specialized (multiplication) methods for it. In your (test) case here, you are constructing a `Matrix` right away, which therefore probably falls back to componentwise `getindex`, which is slow, whereas `Matrix(Q')` uses fast specializations.

My proposal is independent from the above-mentioned PR, and I'm pointing this out just in case this also occurs in code, not just in tests.